### PR TITLE
Upgrade dependencies for Pest 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,9 @@
     ],
     "license": "MIT",
     "require": {
-        "php": "^7.4 || ^8.0",
-        "pestphp/pest": "^1.0",
-        "pestphp/pest-plugin": "^1.0"
+        "php": "^8.1",
+        "pestphp/pest": "^2.0",
+        "pestphp/pest-plugin": "^2.0"
     },
     "autoload": {
         "psr-4": {
@@ -27,13 +27,8 @@
         ]
     },
     "require-dev": {
-        "pestphp/pest-dev-tools": "dev-master",
-        "pestphp/pest-plugin-mock": "^1.0"
-    },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "1.x-dev"
-        }
+        "pestphp/pest-dev-tools": "^2.0",
+        "pestphp/pest-plugin-mock": "^2.0"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,


### PR DESCRIPTION
This PR introduces the following changes:

Upgraded the composer dependencies to support Pest 2.0. This ensures that the package remains compatible with the latest version of Pest, allowing users to benefit from its new features and improvements.

- Updated the PHP dependency to version 8.1. Since Pest 2.0 requires PHP 8.1, it was necessary to upgrade the PHP version in the package as well.

- As these changes introduce breaking changes, I would like to kindly remind you to release a new major version of the package.

- After upgrading all the dependencies, I have run the package tests and can confirm that they pass without any problems.